### PR TITLE
Fix pages not being inverted correctly

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,6 +1,11 @@
 html
 {
+    background-color: black;
+}
+
+body
+{
+    filter: invert(100%);
     background-color: white;
     color: black;
-    filter: invert(100%);
 }


### PR DESCRIPTION
Some web pages had not their colors being inverted correctly (e.g. the
page being blank, or not being wholly inverted).
Examples :

- http://motherfuckingwebsite.com/
- http://bettermotherfuckingwebsite.com/
- https://github.com/Max-Github/FireFoxInvertColors/issues (on large
screen the bottom was still white)

Closes #7