### PR TITLE
Refactor and add support for NOT inverting images

### DIFF
--- a/image.css
+++ b/image.css
@@ -1,0 +1,4 @@
+img
+{
+    filter: invert(100%);
+}

--- a/options.html
+++ b/options.html
@@ -8,7 +8,12 @@
 <body>
   <form>
       <label>Invert Colors State:</label>
-      <button type="submit" id="InvertColorsState">Toggle</button>
+      <input type="checkbox" id="InvertColorsState"/>
+      <br/>
+      <label>Do not invert images:</label>
+      <input type="checkbox" id="ImgColorNoInvert"/>
+      <br/>
+      <button type="submit">Save</button>
   </form>
   <script src="options.js"></script>
 </body>

--- a/options.js
+++ b/options.js
@@ -1,38 +1,23 @@
-function loadOption() {
-	browser.storage.local.get('InvertColorsState').then((res) => {
-		showOption(res.InvertColorsState);
+function loadOptions() {
+	browser.storage.local.get().then((res) => {
+		showOption(res.InvertColorsState, res.ImgColorNoInvert);
 	});
 }
 
-function showOption(state) {
-
-	if (state == true) {
-		document.querySelector("#InvertColorsState").innerHTML = "On";
-	}
-	else {
-		document.querySelector("#InvertColorsState").innerHTML = "Off";
-	}
+function showOption(state, imgNoInvert) {
+	document.querySelector("#InvertColorsState").checked = state;
+	document.querySelector('#ImgColorNoInvert').checked = imgNoInvert;
 }
 
-function toggleOption(e) {
-	browser.storage.local.get('InvertColorsState').then((res) => {
 
-		var state = res.InvertColorsState;
-
-		var newStat = true;
-		if (state == true) {
-			newStat = false;
-		}
-
-		browser.storage.local.set({
-			InvertColorsState: newStat
-		});
-
-		showOption(newStat);
+function updateOptions(e) {
+	browser.storage.local.set({
+		InvertColorsState: document.querySelector('#InvertColorsState').checked,
+		ImgColorNoInvert: document.querySelector('#ImgColorNoInvert').checked
 	});
 
 	e.preventDefault();
 }
 
-document.addEventListener('DOMContentLoaded', loadOption);
-document.querySelector("form").addEventListener("submit", toggleOption);
+document.addEventListener('DOMContentLoaded', loadOptions);
+document.querySelector("form").addEventListener("submit", updateOptions);


### PR DESCRIPTION
New feature: option to disable inverting images

options.{js,html} have been refactored and now can be extended easily
if additional options are required.

background.js has been refactored to streamline the code and provide
improved handling of logic states. On extension load it now also
calls toggleColors() to ensure the browser action icon and tab states
are set correctly.

Closes #14.

Signed-off-by: Tj <hacker@iam.tj>