### PR TITLE
New feature: per-tab invert

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -32,6 +32,7 @@
         "browser_style": true
     },
     "permissions": [
+        "sessions",
         "tabs",
         "storage",
         "contextMenus",


### PR DESCRIPTION
Repurposes the tab's context menu "Invert Colors" menu entry to only
affect the current tab.

Requires the additional 'sessions' permission in order to use
browser.sessions.{get,set}TabValue() for storing per-tab state.

Closes #9.

Signed-of-by: Tj <hacker@iam.tj>