### PR TITLE
Fix global inversion mode and menu button

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -19,7 +19,7 @@ function setColorsToState(tabId, state, imgNoInvert) {
     browser.sessions.setTabValue(tabId, "imgNoInvert", imgNoInvert).then(nullFunc(), nullFunc());
 }
 
-function toggleColors(obj, tab) {
+function toggleColors(changeState, tab) {
     browser.storage.local.get().then((res) => {
       if (tab) {
         browser.sessions.getTabValue(tab.id, "invertColors").then( tabState => {
@@ -31,7 +31,7 @@ function toggleColors(obj, tab) {
         }, nullFunc());
       } else {
         var state = res.InvertColorsState ? res.InvertColorsState : false;
-        state = obj != false ? !state : state;
+        state = changeState ? !state : state;
         setIconState(state);
 
         browser.storage.local.set({ InvertColorsState: state, ImgColorNoInvert: res.ImgColorNoInvert });
@@ -43,6 +43,11 @@ function toggleColors(obj, tab) {
         });
       }
     });
+}
+
+// for wrapping onClickData parameter, see: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus/onClicked#Parameters
+function toggleColorsContextMenu(tabInfo, onClickData){
+	toggleColors(true);
 }
 
 function setIconState(state) {
@@ -122,10 +127,10 @@ browser.contextMenus.create({
 
 browser.tabs.onUpdated.addListener(handleUpdated);
 browser.storage.onChanged.addListener(handleStorageUpdate);
-browser.browserAction.onClicked.addListener(toggleColors);
+browser.browserAction.onClicked.addListener(toggleColorsContextMenu);
 browser.pageAction.onClicked.addListener((tab) => {
     toggleColors(true,tab);
 });
-browser.contextMenus.onClicked.addListener(toggleColors);
+browser.contextMenus.onClicked.addListener(toggleColorsContextMenu);
 
 toggleColors(false);


### PR DESCRIPTION
Fixes #32 #33 

Issue was that the callback from browser.browserAction.onclicked passes 2 arguments to the specified function (toggleColors in that case). Those aren't compatbile for the ones in the arguments list and so the function crashs in line 25 when trying to get the id of the tab. This id attribute is undefined because the actual object (OnClickData object) from the callback isn't a tab. So getTabValue(undefined, "invertColors") is crying about wrong arguments types.

See: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus/onClicked#Parameters

Also some minor refactorings.